### PR TITLE
Awkward Arrays and Wranglers

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,0 +1,66 @@
+import glob
+import json
+from functools import partial
+
+import spacy
+from skpartial.pipeline import make_partial_pipeline
+
+from skword2vec.model.word2vec import Word2VecTransformer
+from skword2vec.preprocessing.spacy import Flattener, SpacyPreprocessor
+from skword2vec.streams import chunk, pipe_streams, stream_files
+
+# Let's imagine we have some jsonl files in the current directory
+paths = glob.glob("./*.jsonl")
+
+# And that all files are made up of entries that contain metadata and
+# textual content for texts.
+# Kinda like this:
+"""
+{"content": "Blablablabla...", "author": "Me and I"}
+{"content": "Habadahabda...", "author": "You"}
+...
+"""
+
+# We build a streaming pipeline:
+stream_text_chunks = pipe_streams(
+    # Streams lines (aka. records) from files.
+    partial(stream_files, lines=True),
+    # We parse them to json
+    partial(map, json.loads),
+    # Then we grab the "content" field
+    partial(map, lambda record: record["content"]),
+    # Then we take chunks of size 10_000
+    # For each iteration of training
+    partial(chunk, chunk_size=10_000),
+)
+
+# Then we build a machine learning pipeline
+
+# We load a Spacy model for English
+nlp = spacy.load("en_core_web_sm")
+# We want all alphabetical tokens, that aren't stop words
+patterns = [[{"IS_ALPHA": True, "IS_STOP": False}]]
+preprocessor = SpacyPreprocessor(nlp, patterns=patterns, out_attribute="LEMMA")
+
+# We create a Skip-gram model with 200 dimensions and window size of 10
+model = Word2VecTransformer(n_components=200, window=10, algorithm="sg")
+
+# Then we create a partial pipeline
+# We need skpartial, since the regular pipeline
+# Won't like partial_fit
+pipeline = make_partial_pipeline(
+    # Spacy preprocessor component
+    preprocessor,
+    # We need to flatten along the zeroth axis
+    # Since the preprocessor returns lists of documents,
+    # But we want list of sentences
+    Flattener(axis=0),
+    # The actual model
+    model,
+)
+
+# Train the model on each chunk
+for i_chunk, text_chunk in enumerate(stream_text_chunks(paths)):
+    pipeline.partial_fit(text_chunk)
+    # We can even save checkpoints
+    model.save(f"models/checkpoint_chunk_{i_chunk}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,18 @@
 [tool.black]
 line-length=79
+
+[tool.poetry]
+name = "word2vec-pipelines"
+version = "0.1.0"
+description = "Tools for training clean and performant word2vec models at scale."
+authors = ["Márton Kardos <power.up1163@gmail.com>", "Jan Kostkan <jan.kostkan@cas.au.dk>"]
+license = "MIT"
+readme = "README.md"
+packages = [{include = "word2vec_pipelines"}]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/skword2vec/model/__init__.py
+++ b/skword2vec/model/__init__.py
@@ -1,0 +1,1 @@
+from .word2vec import Word2VecTransformer

--- a/skword2vec/model/word2vec.py
+++ b/skword2vec/model/word2vec.py
@@ -123,7 +123,7 @@ class Word2VecTransformer(BaseEstimator, TransformerMixin):
     def transform(
         self,
         sentences: Iterable[Iterable[str]],
-    ) -> list[list[ArrayLike]]:
+    ) -> ak.Array:
         """Infers word vectors for all sentences.
 
         Parameters
@@ -133,8 +133,11 @@ class Word2VecTransformer(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        self
-            Fitted model.
+        awkward.Array of shape (n_sentences, n_words, n_dimensions)
+            Ragged array of word embeddings in each sentence.
+            Note that this array can potentially not be used for other
+            applications due to its awkward shape, and you will either
+            have to do pooling or padding to turn it into a numpy array.
         """
         if self.model is None:
             raise NotFittedError("Word2Vec model has not been fitted yet.")
@@ -150,7 +153,7 @@ class Word2VecTransformer(BaseEstimator, TransformerMixin):
                         sent_res.append(np.full(self.n_components, np.nan))
             if sent_res or (self.oov_strategy == "nan"):
                 res.append(sent_res)
-        return res
+        return ak.Array(res)
 
     @property
     def components_(self) -> np.ndarray:

--- a/skword2vec/preprocessing/__init__.py
+++ b/skword2vec/preprocessing/__init__.py
@@ -1,0 +1,1 @@
+from .spacy import SpacyPreprocessor

--- a/skword2vec/preprocessing/spacy.py
+++ b/skword2vec/preprocessing/spacy.py
@@ -104,25 +104,3 @@ class SpacyPreprocessor(TransformerMixin):
                 doc_res.append(sent_tokens)
             res.append(doc_res)
         return res
-
-
-class Flattener(TransformerMixin):
-    """Pipeline component that flattens an iterable along a given axis.
-
-    Parameters
-    ----------
-    axis: int, default 0
-        Axis/level of depth at which the iterable should be flattened.
-    """
-
-    def __init__(self, axis: int = 0):
-        self.axis = axis
-
-    def transform(self, X) -> list:
-        return deeplist(flatten(X, axis=self.axis))
-
-    def fit(self, X, y=None):
-        return self
-
-    def partial_fit(self, X, y=None):
-        return self

--- a/skword2vec/preprocessing/spacy.py
+++ b/skword2vec/preprocessing/spacy.py
@@ -1,0 +1,128 @@
+from typing import Any, Iterable, List, Literal, Optional
+
+from sklearn.base import TransformerMixin
+from spacy.language import Language
+from spacy.matcher import Matcher
+from spacy.tokens import Doc, Token
+
+from skword2vec.streams import deeplist, flatten
+
+# We create a new extension on tokens.
+if not Token.has_extension("filter_pass"):
+    Token.set_extension("filter_pass", default=False)
+
+
+class SpacyPreprocessor(TransformerMixin):
+    """Sklearn pipeline component to preprocess texts with a spaCy pipeline.
+
+    Parameters
+    ----------
+    nlp: Language
+        Spacy NLP pipeline.
+    patterns: list of list of dict
+        List of patterns of tokens to accept and propagate.
+        Patterns follow spaCy's Matcher syntax
+        (https://spacy.io/usage/rule-based-matching#matcher)
+        Every token that is part of a matching pattern will be passed
+        forward, all others will be discarded.
+    out_attribute: {'ORTH', 'NORM', 'LEMMA'}, default 'NORM'
+        Attribute of the token to return as the textual representation.
+    sentencize: bool, default False
+        Determines whether the document should be split into sentences.
+    """
+
+    def __init__(
+        self,
+        nlp: Language,
+        patterns: List[List[dict[str, Any]]],
+        out_attribute: Literal["ORTH", "NORM", "LEMMA"] = "NORM",
+        sentencize: bool = False,
+    ):
+        self.nlp = nlp
+        self.patterns = patterns
+        self.out_attribute = out_attribute
+        self.matcher = Matcher(nlp.vocab)
+        self.matcher.add("FILTER_PASS", patterns=patterns)
+        self.sentencize = sentencize
+
+    def fit(self, X, y=None):
+        """Exists for compatiblity, doesn't do anything."""
+        return self
+
+    def partial_fit(self, X, y=None):
+        """Exists for compatiblity, doesn't do anything."""
+        return self
+
+    def label_matching_tokens(self, docs: list[Doc]):
+        """Labels tokens that match one of the given patterns."""
+        for doc in docs:
+            matches = self.matcher(doc)
+            for _, start, end in matches:
+                for token in doc[start:end]:
+                    token._.set("filter_pass", True)
+
+    def token_to_str(self, token: Token) -> str:
+        """Returns textual representation of token."""
+        if self.out_attribute == "ORTH":
+            return token.orth_
+        elif self.out_attribute == "NORM":
+            return token.norm_
+        else:
+            return token.lemma_
+
+    def transform(self, X: Iterable[str]) -> list[list[list[str]]]:
+        """Preprocesses document with a spaCy pipeline.
+
+        Parameters
+        ----------
+        X: iterable of str
+            Stream of documents.
+
+        Returns
+        -------
+        list of list of list of str
+            List of documents represented as list of sentences
+            represented as lists of tokens.
+        """
+        docs = list(self.nlp.pipe(X))
+        # Label all tokens according to the patterns.
+        self.label_matching_tokens(docs)
+        res: list[list[list[str]]] = []
+        for doc in docs:
+            doc_res: list[list[str]] = []
+            # We act as if the entire doc was one sentence
+            # if sentencize is false.
+            sents = doc.sents if self.sentencize else [doc]
+            for sent in sents:
+                # We collect the textual representation of
+                # all tokens that pass the filter.
+                sent_tokens = [
+                    self.token_to_str(token)
+                    for token in sent
+                    if token._.filter_pass
+                ]
+                doc_res.append(sent_tokens)
+            res.append(doc_res)
+        return res
+
+
+class Flattener(TransformerMixin):
+    """Pipeline component that flattens an iterable along a given axis.
+
+    Parameters
+    ----------
+    axis: int, default 0
+        Axis/level of depth at which the iterable should be flattened.
+    """
+
+    def __init__(self, axis: int = 0):
+        self.axis = axis
+
+    def transform(self, X) -> list:
+        return deeplist(flatten(X, axis=self.axis))
+
+    def fit(self, X, y=None):
+        return self
+
+    def partial_fit(self, X, y=None):
+        return self

--- a/skword2vec/preprocessing/spacy.py
+++ b/skword2vec/preprocessing/spacy.py
@@ -29,6 +29,9 @@ class SpacyPreprocessor(TransformerMixin):
         Attribute of the token to return as the textual representation.
     sentencize: bool, default False
         Determines whether the document should be split into sentences.
+    n_jobs: int, default 1
+        Number of cores to use for preprocessing with spaCy.
+        -1 stands for all cores.
     """
 
     def __init__(
@@ -37,6 +40,7 @@ class SpacyPreprocessor(TransformerMixin):
         patterns: List[List[dict[str, Any]]],
         out_attribute: Literal["ORTH", "NORM", "LEMMA"] = "NORM",
         sentencize: bool = False,
+        n_jobs: int = 1,
     ):
         self.nlp = nlp
         self.patterns = patterns
@@ -44,6 +48,7 @@ class SpacyPreprocessor(TransformerMixin):
         self.matcher = Matcher(nlp.vocab)
         self.matcher.add("FILTER_PASS", patterns=patterns)
         self.sentencize = sentencize
+        self.n_jobs = n_jobs
 
     def fit(self, X, y=None):
         """Exists for compatiblity, doesn't do anything."""
@@ -84,7 +89,7 @@ class SpacyPreprocessor(TransformerMixin):
             List of documents represented as list of sentences
             represented as lists of tokens.
         """
-        docs = list(self.nlp.pipe(X))
+        docs = list(self.nlp.pipe(X, n_process=self.n_jobs))
         # Label all tokens according to the patterns.
         self.label_matching_tokens(docs)
         res: list[list[list[str]]] = []

--- a/skword2vec/streams.py
+++ b/skword2vec/streams.py
@@ -5,7 +5,7 @@ from itertools import islice
 from typing import Callable, Iterable, List, Literal, Optional, TypeVar, Union
 
 
-def pipe(*transforms: Callable) -> Callable:
+def pipe_streams(*transforms: Callable) -> Callable:
     """Pipes iterator transformations together.
 
     Parameters

--- a/skword2vec/streams.py
+++ b/skword2vec/streams.py
@@ -178,6 +178,18 @@ def flatten(nested: Iterable, axis: int = 0) -> Iterable:
 
 
 def deeplist(nested) -> list:
+    """Recursively turns nested iterable to list.
+
+    Parameters
+    ----------
+    nested: iterable
+        Nested iterable.
+
+    Returns
+    -------
+    list
+        Nested list.
+    """
     if not isinstance(nested, Iterable) or isinstance(nested, str):
         return nested  # type: ignore
     else:

--- a/skword2vec/wranglers/__init__.py
+++ b/skword2vec/wranglers/__init__.py
@@ -1,0 +1,3 @@
+from .flattener import Flattener
+from .padder import Padder
+from .pooler import Pooler

--- a/skword2vec/wranglers/flattener.py
+++ b/skword2vec/wranglers/flattener.py
@@ -1,27 +1,43 @@
-from typing import Iterable
+from typing import Union
 
+import awkward as ak
+from numpy.typing import ArrayLike
 from sklearn.base import BaseEstimator, TransformerMixin
-
-from skword2vec.streams import flatten
 
 
 class Flattener(TransformerMixin, BaseEstimator):
-    """Pipeline component that flattens an iterable along a given axis.
+    """Pipeline component that flattens an array along a given axis.
+    Note that this component does not accept iterables, only Awkward Arrays
+    and ArrayLike objects.
 
     Parameters
     ----------
-    axis: int, default 0
+    axis: int, default 1
         Axis/level of depth at which the iterable should be flattened.
     """
 
-    def __init__(self, axis: int = 0):
+    def __init__(self, axis: int = 1):
         self.axis = axis
 
-    def transform(self, X) -> Iterable:
-        return flatten(X, axis=self.axis)
+    def transform(self, X: Union[ArrayLike, ak.Array]) -> ak.Array:
+        """Flattens the given iterable along the axis of the Flattener.
+
+        Parameters
+        ----------
+        X: ArrayLike or ak.Array
+            Array to flatten.
+
+        Returns
+        -------
+        ak.Array
+            Awkward Array, flattened along the given axis.
+        """
+        return ak.flatten(X, axis=self.axis)
 
     def fit(self, X, y=None):
+        """Does nothing, exists for compatibility."""
         return self
 
     def partial_fit(self, X, y=None):
+        """Does nothing, exists for compatibility."""
         return self

--- a/skword2vec/wranglers/flattener.py
+++ b/skword2vec/wranglers/flattener.py
@@ -1,0 +1,27 @@
+from typing import Iterable
+
+from sklearn.base import BaseEstimator, TransformerMixin
+
+from skword2vec.streams import flatten
+
+
+class Flattener(TransformerMixin, BaseEstimator):
+    """Pipeline component that flattens an iterable along a given axis.
+
+    Parameters
+    ----------
+    axis: int, default 0
+        Axis/level of depth at which the iterable should be flattened.
+    """
+
+    def __init__(self, axis: int = 0):
+        self.axis = axis
+
+    def transform(self, X) -> Iterable:
+        return flatten(X, axis=self.axis)
+
+    def fit(self, X, y=None):
+        return self
+
+    def partial_fit(self, X, y=None):
+        return self

--- a/skword2vec/wranglers/padder.py
+++ b/skword2vec/wranglers/padder.py
@@ -1,0 +1,58 @@
+import warnings
+from typing import Any, Optional
+
+import awkward as ak
+from sklearn.base import BaseEstimator, TransformerMixin
+
+
+class Padder(TransformerMixin, BaseEstimator):
+    """Pipeline component that pads a ragged array along a given axis.
+
+    Parameters
+    ----------
+    axis: int, default 1
+        Axis along which the array should be padded.
+    target: int or None, default None
+        Intended dimensionality along the given axis.
+        If not specified, maximum dimensionality is learned
+        from the data and is used.
+    fill_value: Any, default None
+        Value to fill empty slots with.
+    """
+
+    def __init__(
+        self,
+        axis: int = 1,
+        target: Optional[int] = None,
+        fill_value: Any = None,
+    ):
+        self.axis = axis
+        self.target = target
+        self.fill_value = fill_value
+
+    def transform(self, X: ak.Array):
+        if self.target is None:
+            warnings.warn(
+                "Max padding length has not been learned during fitting, "
+                "Using maximum length of data along the given dimension."
+                " Consider calling fit() to save this in the padder's state."
+            )
+            target = ak.max(ak.num(X, axis=self.axis))
+        else:
+            target = self.target
+        X = ak.pad_none(X, target=target, axis=self.axis)
+        if self.fill_value is not None:
+            X = ak.fill_none(X, self.fill_value, axis=self.axis)
+        return X
+
+    def fit(self, X: ak.Array, y=None):
+        self.target = ak.max(ak.num(X, axis=self.axis))
+        return self
+
+    def partial_fit(self, X, y=None):
+        target = ak.max(ak.num(X, axis=self.axis))
+        if self.target is None:
+            self.target = target
+        else:
+            self.target = max(target, self.target)
+        return self

--- a/skword2vec/wranglers/padder.py
+++ b/skword2vec/wranglers/padder.py
@@ -30,7 +30,19 @@ class Padder(TransformerMixin, BaseEstimator):
         self.target = target
         self.fill_value = fill_value
 
-    def transform(self, X: ak.Array):
+    def transform(self, X) -> ak.Array:
+        """Padds ragged array along given axis.
+
+        Parameters
+        ----------
+        X: ArrayLike
+            Object that can be transformed into an Awkward Array.
+
+        Returns
+        -------
+        ak.Array
+            Awkward Array padded.
+        """
         if self.target is None:
             warnings.warn(
                 "Max padding length has not been learned during fitting, "
@@ -46,10 +58,40 @@ class Padder(TransformerMixin, BaseEstimator):
         return X
 
     def fit(self, X: ak.Array, y=None):
-        self.target = ak.max(ak.num(X, axis=self.axis))
+        """Learns maximal padding needed. If target is specified,
+        nothing happens.
+
+        Parameters
+        ----------
+        X: ArrayLike
+            Object that can be transformed into an Awkward Array.
+
+        Returns
+        -------
+        self
+        """
+        target = ak.max(ak.num(X, axis=self.axis))
+        if self.target is None:
+            self.target = target
+        elif self.target < target:
+            warnings.warn(
+                f"Target dimensionality along axis ({self.target}) is smaller "
+                f"than maximum observed during fitting ({target})"
+            )
         return self
 
     def partial_fit(self, X, y=None):
+        """Learns or updates maximal padding needed.
+
+        Parameters
+        ----------
+        X: ArrayLike
+            Object that can be transformed into an Awkward Array.
+
+        Returns
+        -------
+        self
+        """
         target = ak.max(ak.num(X, axis=self.axis))
         if self.target is None:
             self.target = target

--- a/skword2vec/wranglers/pooler.py
+++ b/skword2vec/wranglers/pooler.py
@@ -1,0 +1,33 @@
+from typing import Callable
+
+import numpy as np
+from sklearn.base import BaseEstimator, TransformerMixin
+
+
+class Pooler(TransformerMixin, BaseEstimator):
+    """Pipeline component that pools an array along a given axis.
+
+    Parameters
+    ----------
+    agg: Callable, default np.nanmean
+        Function to pool the results with.
+    axis: int, default 0
+        Axis/level of depth at which the iterable should be flattened.
+        If agg does not accept an axis keyword, this parameter is ignored.
+    """
+
+    def __init__(self, agg: Callable = np.nanmean, axis: int = 0):
+        self.axis = axis
+        self.agg = agg
+
+    def transform(self, X):
+        try:
+            return self.agg(X, axis=self.axis)
+        except TypeError:
+            return self.agg(X)
+
+    def fit(self, X, y=None):
+        return self
+
+    def partial_fit(self, X, y=None):
+        return self

--- a/skword2vec/wranglers/pooler.py
+++ b/skword2vec/wranglers/pooler.py
@@ -11,23 +11,37 @@ class Pooler(TransformerMixin, BaseEstimator):
     ----------
     agg: Callable, default np.nanmean
         Function to pool the results with.
-    axis: int, default 0
+    axis: int, default 1
         Axis/level of depth at which the iterable should be flattened.
         If agg does not accept an axis keyword, this parameter is ignored.
     """
 
-    def __init__(self, agg: Callable = np.nanmean, axis: int = 0):
+    def __init__(self, agg: Callable = np.nanmean, axis: int = 1):
         self.axis = axis
         self.agg = agg
 
     def transform(self, X):
+        """Pools array along given axis with given aggregator function.
+
+        Parameters
+        ----------
+        X: ArrayLike
+            Array to pool.
+
+        Returns
+        -------
+        ArrayLike
+            Pooled array.
+        """
         try:
             return self.agg(X, axis=self.axis)
         except TypeError:
             return self.agg(X)
 
     def fit(self, X, y=None):
+        """Does nothing, exists for compatibility."""
         return self
 
     def partial_fit(self, X, y=None):
+        """Does nothing, exists for compatibility."""
         return self


### PR DESCRIPTION
### Changes in API
`Word2VecTransformer` now takes a list of documents instead of a list of sentences, meaning one level of nesting has been added.
```python
# old signature:
def transform(self, sentences: Iterable[Iterable[str]]):
    pass

# new signature:
def transform(self, documents: Iterable[Iterable[Iterable[str]]]):
    pass
```
This is useful, as now you can pipe `SpacyPreprocessor` and `Word2VecTransformer` directly into each other.
```python
from sklearn.pipeline import make_pipeline

pipeline = make_pipeline(SpacyPreprocessor(nlp), Word2VecTransformer())
``` 
`Word2VecTransformer` now outputs a ragged *Awkward Array* instead of `List[List[np.ndarray]]`.
This is great as now you can directly do arithmetic and all sorts of operations on these arrays.
What's also great about both of these changes is that the internal structure of the data remains paramount, therefore you can uniquely identify documents in the transformer's output.

### Wranglers

Wrangler components are now part of the codebase, which you can use for manipulating (potentially ragged) arrays in a machine learning pipeline.
Three wranglers have been added: `Flattener`, which flattens arrays along a given axis, `Pooler` which can reduce the dimensionality of arrays with an aggregation and `Padder` which can pad ragged arrays along a given axis.
These are rather useful, because you can easily manipulate the output of the `Word2VecTransformer` to be in a particular format that you might want to use in following pipeline components, let's say regression or classification models.
Here's a quick example of how you would build a pipeline, that takes the mean of all vectors in a documents, thereby giving a single embedding for each of them.

```python
pipeline = make_pipeline(
    SpacyPreprocessor(nlp),
    Word2VecTransformer(),
    # Pooling sentences together (aka. taking mean of all embeddings)
    Pooler(axis=2),
    # Pooling all sentences in a document
    # axis=1 is the default.
    Pooler()
)
```