### PR TITLE
Static embeddings

### DIFF
--- a/skword2vec/model/static.py
+++ b/skword2vec/model/static.py
@@ -1,0 +1,154 @@
+from typing import Iterable, Literal
+
+import awkward as ak
+import numpy as np
+from numpy.typing import ArrayLike
+from sklearn.base import BaseEstimator, TransformerMixin
+
+from skword2vec.streams import deeplist
+
+
+def count_to_offset(sent_word_counts: list[int]):
+    offsets = np.cumsum(sent_word_counts)
+    offsets = np.concatenate(([0], offsets))
+    return ak.index.Index(offsets)
+
+
+def build_ragged_array(
+    sent_word_counts: list[int],
+    doc_sent_counts: list[int],
+    embeddings: np.ndarray,
+) -> ak.Array:
+    offset = count_to_offset(sent_word_counts)
+    contents = ak.contents.NumpyArray(embeddings)
+    ragged = ak.contents.ListOffsetArray(offset, contents)
+    ragged = ak.unflatten(ragged, doc_sent_counts, axis=0)
+    return ragged
+
+
+class StaticWordVectorizer(BaseEstimator, TransformerMixin):
+    """Vectorizes text documents with arbitrarily derived
+    static word embeddings.
+
+    Parameters
+    ----------
+    embeddings: array-like of shape (n_vocab, n_components)
+        All word embeddings stacked into a matrix, where every row
+        corresponds to one word.
+    vocab: array-like of shape (n_vocab)
+        Vocabulary of the static embedding model.
+    oov_strategy: {'drop', 'nan'}, default 'drop'
+        Indicates whether you want out-of-vocabulary
+        words to have a vector filled with nans or
+        drop them.
+
+    Attributes
+    ----------
+    key_to_index: dict[str, int]
+        Mapping of words to their indices in the vocabulary.
+    components_: array of shape (n_components, n_vocab)
+        Matrix of all embeddings in the model.
+        Note that this is the transposed embeddings,
+        the reason for this is that topic models and other
+        decomposition models in sklearn also have components with
+        this kind of shape.
+    feature_names_in_: array of shape (n_vocab)
+        Vocabulary of the static embedding model.
+    """
+
+    def __init__(
+        self,
+        embeddings: ArrayLike,
+        vocab: ArrayLike,
+        oov_strategy: Literal["drop", "nan"] = "nan",
+    ):
+        self.embeddings = np.array(embeddings)
+        self.vocab = np.array(vocab)
+        self.key_to_index = {
+            term: index for index, term in enumerate(self.vocab)
+        }
+        self.n_vocab, self.n_components = self.embeddings.shape
+        self.oov_strategy = oov_strategy
+
+    def fit(self, documents: Iterable[Iterable[Iterable[str]]], y=None):
+        """Does nothing, exists for compatibility."""
+        return self
+
+    def partial_fit(
+        self, documents: Iterable[Iterable[Iterable[str]]], y=None
+    ):
+        """Does nothing, exists for compatibility."""
+        return self
+
+    def transform(
+        self, documents: Iterable[Iterable[Iterable[str]]]
+    ) -> ak.Array:
+        """Infers word vectors for all sentences.
+
+        Parameters
+        ----------
+        documents: deep iterable with dimensions (documents, sentences, words)
+            Words in each sentence in each document.
+
+        Returns
+        -------
+        awkward.Array with dimensions (documents, sentences, words, dimensions)
+            Ragged array of word embeddings in each sentence in each document.
+            Note that this array can potentially not be used for other
+            applications due to its awkward shape, and you will either
+            have to do pooling or padding to turn it into a numpy array.
+        """
+        documents = deeplist(documents)
+        sent_word_counts = []
+        doc_sent_counts = []
+        words = []
+        for doc in documents:
+            doc_sent_counts.append(len(doc))  # type: ignore
+            for sent in doc:
+                sent_word_counts.append(len(sent))  # type: ignore
+                words.extend(sent)
+        embeddings = np.full((len(words), self.n_components), np.nan)
+        for i_word, word in enumerate(words):
+            try:
+                embeddings[i_word, :] = self.embeddings[
+                    self.key_to_index[word]
+                ]
+            except KeyError:
+                continue
+        embeddings = build_ragged_array(
+            sent_word_counts, doc_sent_counts, embeddings
+        )
+        if self.oov_strategy == "drop":
+            embeddings = ak.nan_to_none(embeddings)
+            embeddings = ak.drop_none(embeddings)
+        return embeddings
+
+    @property
+    def components_(self) -> np.ndarray:
+        return np.array(self.embeddings).T
+
+    @property
+    def feature_names_in_(self) -> np.ndarray:
+        return self.vocab
+
+    @classmethod
+    def from_keyed_vectors(
+        cls, keyed_vectors, oov_strategy: Literal["drop", "nan"] = "nan"
+    ) -> "StaticWordVectorizer":
+        """Initializes static embedding vectorizer component from
+        Gensim keyed vectors.
+
+        Parameters
+        ----------
+        keyed_vectors: KeyedVectors
+            Keyed vectors from Gensim model.
+        oov_strategy: {'drop', 'nan'}, default 'drop'
+            Indicates whether you want out-of-vocabulary
+            words to have a vector filled with nans or
+            drop them.
+        """
+        vocab = np.array(keyed_vectors.index_to_key)
+        embeddings = keyed_vectors.vectors
+        return cls(
+            vocab=vocab, embeddings=embeddings, oov_strategy=oov_strategy
+        )

--- a/skword2vec/model/word2vec.py
+++ b/skword2vec/model/word2vec.py
@@ -27,7 +27,7 @@ def build_ragged_array(
     return ragged
 
 
-class Word2VecTransformer(BaseEstimator, TransformerMixin):
+class Word2VecVectorizer(BaseEstimator, TransformerMixin):
     """Scikit-learn compatible Word2Vec model.
 
     Parameters
@@ -92,7 +92,7 @@ class Word2VecTransformer(BaseEstimator, TransformerMixin):
         oov_strategy: Literal["drop", "nan"] = "nan",
         frozen: bool = False,
     ):
-        """Creates Word2VecTransformer from the given Gensim Word2Vec model.
+        """Creates Word2VecVectorizer from the given Gensim Word2Vec model.
 
         Parameters
         ----------
@@ -110,7 +110,7 @@ class Word2VecTransformer(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        Word2VecTransformer
+        Word2VecVectorizer
             Transformer object with the given Word2Vec model.
         """
         res = cls(
@@ -273,7 +273,7 @@ class Word2VecTransformer(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        Word2VecTransformer
+        Word2VecVectorizer
             Transformer component.
         """
         model = Word2Vec.load(path)


### PR DESCRIPTION
### Static embedding models
Added `StaticWordVectorizer` which has the exact same behaviour as Word2Vec, but can be based on any static embedding model. This can also be quite advantageous as users can just save `KeyedVectors` instances to disk (which are smaller) and use them with this pipeline component, as it is more lightweight.

### Renamed `Word2VecTransformer` to `Word2VecVectorizer`
I thought this name would suit the naming conventions of scikit-learn better as usually estimators that turn text into vectorized form are called `Vectorizer` and `Transformer` is reserved for components that do number crunching. For example in the case of tf-idf, `TfidfVectorizer` is the component that turns text into vectors, and `TfidfTransformer` transforms BOW vectors into tf-idf ones.
I must admit I'm not quite sure whether this is a good change or not, since our components are still fundamentally in that they take ragged iterables of strings and return ragged tensors. But that's just how word vectorization is I guess.