### PR TITLE
Flattener API Clarified

### DIFF
--- a/skword2vec/model/word2vec.py
+++ b/skword2vec/model/word2vec.py
@@ -6,7 +6,7 @@ from gensim.models import Word2Vec
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.exceptions import NotFittedError
 
-from skword2vec.streams import deeplist, flatten
+from skword2vec.streams import deeplist, flatten_stream
 
 
 def count_to_offset(sent_word_counts: list[int]):
@@ -170,7 +170,7 @@ class Word2VecTransformer(BaseEstimator, TransformerMixin):
         """
         if self.frozen:
             return self
-        sentences = flatten(documents, axis=0)
+        sentences = flatten_stream(documents, axis=1)
         sentences = deeplist(sentences)
         if self.model is None:
             self.model = Word2Vec(

--- a/skword2vec/preprocessing/spacy.py
+++ b/skword2vec/preprocessing/spacy.py
@@ -5,8 +5,6 @@ from spacy.language import Language
 from spacy.matcher import Matcher
 from spacy.tokens import Doc, Token
 
-from skword2vec.streams import deeplist, flatten
-
 # We create a new extension on tokens.
 if not Token.has_extension("filter_pass"):
     Token.set_extension("filter_pass", default=False)
@@ -77,7 +75,8 @@ class SpacyPreprocessor(TransformerMixin):
         else:
             raise ValueError(
                 """Unrecognized `out_attribute`.
-                Please chose one of `"ORTH", "NORM", "LEMMA"`""")
+                Please chose one of `"ORTH", "NORM", "LEMMA"`"""
+            )
 
     def transform(self, X: Iterable[str]) -> list[list[list[str]]]:
         """Preprocesses document with a spaCy pipeline.

--- a/skword2vec/streams.py
+++ b/skword2vec/streams.py
@@ -145,20 +145,26 @@ def stream_files(
             else:
                 raise ValueError(
                     """Unrecognized `not_found_action`.
-                    Please chose one of `"exception", "none", "drop"`""")
+                    Please chose one of `"exception", "none", "drop"`"""
+                )
 
 
 @reusable
-def flatten(nested: Iterable, axis: int = 0) -> Iterable:
+def flatten_stream(nested: Iterable, axis: int = 1) -> Iterable:
     """Turns nested stream into a flat stream.
     If multiple levels are nested, the iterable will be flattenned along
     the given axis.
+
+    To match the behaviour of Awkward Array flattening, axis=0 only
+    removes None elements from the array along the outermost axis.
+
+    Negative axis values are not yet supported.
 
     Parameters
     ----------
     nested: iterable
         Iterable of iterables of unknown depth.
-    axis: int, default 0
+    axis: int, default 1
         Axis/level of depth at which the iterable should be flattened.
 
     Returns
@@ -171,12 +177,14 @@ def flatten(nested: Iterable, axis: int = 0) -> Iterable:
             f"Nesting is too deep, values at level {axis} are not iterables"
         )
     if axis == 0:
+        return (elem for elem in nested if elem is not None and (elem != []))
+    if axis == 1:
         for sub in nested:
             for elem in sub:
                 yield elem
-    elif axis > 0:
+    elif axis > 1:
         for sub in nested:
-            yield flatten(sub, axis=axis - 1)
+            yield flatten_stream(sub, axis=axis - 1)
     else:
         raise ValueError("Flattening axis needs to be greater than 0.")
 

--- a/skword2vec/wranglers/__init__.py
+++ b/skword2vec/wranglers/__init__.py
@@ -1,3 +1,3 @@
-from .flattener import Flattener
+from .flattener import ArrayFlattener, StreamFlattener
 from .padder import Padder
 from .pooler import Pooler

--- a/skword2vec/wranglers/flattener.py
+++ b/skword2vec/wranglers/flattener.py
@@ -1,14 +1,61 @@
-from typing import Union
+from typing import Iterable, Union
 
 import awkward as ak
 from numpy.typing import ArrayLike
 from sklearn.base import BaseEstimator, TransformerMixin
 
+from skword2vec.streams import flatten_stream
 
-class Flattener(TransformerMixin, BaseEstimator):
+
+class StreamFlattener(TransformerMixin, BaseEstimator):
+    """Flattens iterable stream along given axis.
+
+    The important distinction between this and ArrayFlattener,
+    is that StreamFlattener does computes lazily and creates a generator
+    instead of constructing an Awkward Array. This can have a positive
+    impact on performance especially when the data structure is
+    not a tensor to begin with.
+
+    Parameters
+    ----------
+    axis: int, default 1
+        Axis/level of depth at which the iterable should be flattened.
+    """
+
+    def __init__(self, axis: int = 1):
+        self.axis = axis
+
+    def transform(self, X: Iterable) -> Iterable:
+        """Flattens the given iterable along the axis.
+
+        Parameters
+        ----------
+        X: nested iterable
+            Iterable to flatten.
+
+        Returns
+        -------
+        iterable
+            Iterable that gets flattened along the given axis.
+        """
+        return flatten_stream(X, axis=self.axis)
+
+    def fit(self, X, y=None):
+        """Does nothing, exists for compatibility."""
+        return self
+
+    def partial_fit(self, X, y=None):
+        """Does nothing, exists for compatibility."""
+        return self
+
+
+class ArrayFlattener(TransformerMixin, BaseEstimator):
     """Pipeline component that flattens an array along a given axis.
-    Note that this component does not accept iterables, only Awkward Arrays
-    and ArrayLike objects.
+
+    Note that this component does eager evaluation and conversion to
+    Akward Array, therefore it might not be ideal for streams.
+    We recommend that you use this component when the output of the previous
+    component is a tensor/array or Awkward Array.
 
     Parameters
     ----------
@@ -20,7 +67,7 @@ class Flattener(TransformerMixin, BaseEstimator):
         self.axis = axis
 
     def transform(self, X: Union[ArrayLike, ak.Array]) -> ak.Array:
-        """Flattens the given iterable along the axis of the Flattener.
+        """Flattens the given array along the axis.
 
         Parameters
         ----------


### PR DESCRIPTION
### `ArrayFlattener` and `StreamFlattener`
I added a new class called `StreamFlattener` and renamed the other one to `ArrayFlattener`.
These have been made to have the exact same behaviour, except for the time of evaluation.
`StreamFlattener` returns a generator, so it streams the data that is being passed to it, thereby being lazily evaluated.
`ArrayFlattener` evaluates eagerly and constructs an Akward Array. This is great for Numpy and Awkward Arrays, but it could be terrible for streams as it constructs the array from scratch.

### `flatten_stream()`
I renamed `flatten()` to `flatten_stream()` so that the distinction is clear.


Note:
A potential gotcha of this thing could be the repeatability of `Iterable` and generator objects. Since we are dealing with nested iterables this could present a serious problem when somebody wants to pass over a document or a chunk or a file multiple times. This either has to be documented or we have to do some black magic to counter its effects.